### PR TITLE
Avoid concatenation of duplicate client_id for the application_id

### DIFF
--- a/lib/azure/directory.rb
+++ b/lib/azure/directory.rb
@@ -44,9 +44,7 @@ module Azure
 			# @return [OAuth2::AccessToken] a access token for the current session.
 			#
 			def fetch_access_token!
-				@oauth_token = oauth.get_token( :client_id => config.client_id, 
-					                            :client_secret => config.client_secret, 
-					                            :grant_type => 'client_credentials', 
+				@oauth_token = oauth.get_token( :grant_type => 'client_credentials', 
 					                            :response_type => 'client_credentials', 
 					                            :resource => config.resource_id )
 


### PR DESCRIPTION
When requesting the token (get_token) with the OAuth2 Client, the application_id used by Azure is formed by the OAuth2.Client.client_id + client_id passed as a param for the get_token so this results in the duplicity of the client_id and an invalid application_id that can't be found in Azure Directory.

This pull request proposes to take out the client_id and the client_secret from the get_token method because it already uses the OAuth2 Client params.